### PR TITLE
Add usart baudrate config

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
     "target_address": "2",
     "port": "10",
     "uart_bus": "K_UART6",
+    "uart_baudrate": "115200",
     "usart": {
     }
   }

--- a/source/main.c
+++ b/source/main.c
@@ -42,13 +42,15 @@
 *           "target_address": "2",
 *           "port": "10",
 *           "uart_bus": "K_UART6",
+*           "uart_baudrate": "115200",
 *           "usart": {
 *           }
 *      }
 *  }
 *
-* This would create enable CSP KISS, the address of your device and target device,
-* the listening port and UART interface. Invert the addresses when flashing the target board.
+* This would create and enable CSP KISS with the address of your device, the target device,
+* the listening port, and the UART interface and baudrate. The addresses must be inverted for 
+* the second device of the example pair.
 */
 
 #define MY_ADDRESS YOTTA_CFG_CSP_MY_ADDRESS

--- a/source/main.c
+++ b/source/main.c
@@ -239,6 +239,7 @@ int main(void)
     /* set the device in KISS / UART interface */
     char dev = (char)YOTTA_CFG_CSP_UART_BUS;
     conf.device = &dev;
+    conf.baudrate = K_UART_CONSOLE_BAUDRATE;
     usart_init(&conf);
 
     /* init kiss interface */

--- a/source/main.c
+++ b/source/main.c
@@ -54,6 +54,7 @@
 #define MY_ADDRESS YOTTA_CFG_CSP_MY_ADDRESS
 #define TARGET_ADDRESS YOTTA_CFG_CSP_TARGET_ADDRESS
 #define MY_PORT    YOTTA_CFG_CSP_PORT
+#define MY_BAUDRATE YOTTA_CFG_CSP_UART_BAUDRATE
 #define BLINK_MS 100
 
 static xQueueHandle button_queue;
@@ -239,7 +240,7 @@ int main(void)
     /* set the device in KISS / UART interface */
     char dev = (char)YOTTA_CFG_CSP_UART_BUS;
     conf.device = &dev;
-    conf.baudrate = K_UART_CONSOLE_BAUDRATE;
+    conf.baudrate = MY_BAUDRATE;
     usart_init(&conf);
 
     /* init kiss interface */


### PR DESCRIPTION
Added usart baud rate configuration so the baud rate is explicitly set. This ensures that the example flashed on different development boards I.e. pyboard and stm32 discovery are configured the same.

CC/ @kubostech/devs 